### PR TITLE
fix: add missing await on field.update() in processFieldRef

### DIFF
--- a/src/handlers/lists.ts
+++ b/src/handlers/lists.ts
@@ -383,7 +383,7 @@ export class Lists extends HandlerBase {
         ...(fieldReference.AdditionalProperties ?? {})
       })
       const fieldAddResult = await list.fields.createFieldAsXml(schemaXml)
-      fieldAddResult.field.update({
+      await fieldAddResult.field.update({
         Title: fieldReference.DisplayName,
         Required: fieldReference.Required,
         Hidden: fieldReference.Hidden


### PR DESCRIPTION
## Summary
- Adds missing `await` on `fieldAddResult.field.update()` in `processFieldRef` (`src/handlers/lists.ts`)
- Without `await`, the `.reduce()` chain moves to the next field ref while the previous `field.update()` is still in-flight
- This causes intermittent 500 errors from SharePoint (`HRESULT 0x8007047E`) when adding multiple field refs to a list

## Root cause
In `processFieldRef`, when a web field is added to a list via `createFieldAsXml`, the subsequent `field.update()` call (which sets Title, Required, Hidden) was fire-and-forget. The sequential `.reduce()` chain in `processListFieldRefs` would immediately proceed to the next field, causing overlapping mutations on the same list.

## Test plan
- [ ] Run project setup on a site with multiple lists that have FieldRefs
- [ ] Confirm the 500 error no longer occurs
- [ ] Run setup multiple times to verify consistency