### PR TITLE
fix: håndter arvede content type field links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sp-js-provisioning",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sp-js-provisioning",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "license": "MIT",
       "dependencies": {
         "@pnp/core": "3.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sp-js-provisioning",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "SharePoint provisioning with pure JavaScript",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/handlers/contenttypes.ts
+++ b/src/handlers/contenttypes.ts
@@ -11,6 +11,13 @@ interface ContentTypeCreationInformationWithId
   set_id(value: string): void
 }
 
+interface CurrentFieldLink {
+  ID: string
+  Name: string
+  Required: boolean
+  Hidden: boolean
+}
+
 /**
  * Describes the Content Types Object Handler
  */
@@ -149,14 +156,40 @@ export class ContentTypes extends HandlerBase {
   }
 
   private getExistingFieldLink(
-    contentType: IContentType,
-    fieldName: string
-  ): IFieldReference {
-    const ct =
-      this.context.contentTypes[contentType.Name] ??
-      this.context.contentTypes[contentType.ID]
-    const existingFieldLink = ct?.FieldRefs?.find((fr) => fr.Name === fieldName)
-    return existingFieldLink
+    currentFieldLinks: CurrentFieldLink[],
+    fieldReference: IFieldReference
+  ): CurrentFieldLink {
+    const fieldReferenceId = this.normalizeGuid(fieldReference.ID)
+    return currentFieldLinks.find((fieldLink) => {
+      return (
+        fieldLink.Name === fieldReference.Name ||
+        this.normalizeGuid(fieldLink.ID) === fieldReferenceId
+      )
+    })
+  }
+
+  private normalizeGuid(guid: string): string {
+    return (guid ?? '').replace(/[{}]/g, '').toLowerCase()
+  }
+
+  private async getCurrentFieldLinks(
+    spContentType: SP.ContentType
+  ): Promise<CurrentFieldLink[]> {
+    const fieldLinks = spContentType.get_fieldLinks()
+    await ExecuteJsomQuery(this.jsomContext, [{ clientObject: fieldLinks }])
+
+    const currentFieldLinks: CurrentFieldLink[] = []
+    const enumerator = fieldLinks.getEnumerator()
+    while (enumerator.moveNext()) {
+      const fieldLink = enumerator.get_current()
+      currentFieldLinks.push({
+        ID: fieldLink.get_id().toString(),
+        Name: fieldLink.get_name(),
+        Required: fieldLink.get_required(),
+        Hidden: fieldLink.get_hidden()
+      })
+    }
+    return currentFieldLinks
   }
 
   /**
@@ -169,69 +202,60 @@ export class ContentTypes extends HandlerBase {
     contentType: IContentType,
     spContentType: SP.ContentType
   ): Promise<void> {
-    try {
-      const fieldRefs = contentType.FieldRefs
-      for (const [index, fieldReference] of fieldRefs.entries()) {
-        const existingFieldLink = this.getExistingFieldLink(
-          contentType,
-          fieldReference.Name
-        )
-        let fieldLink: SP.FieldLink
-        if (existingFieldLink) {
-          fieldLink = spContentType
-            .get_fieldLinks()
-            .getById(new SP.Guid(existingFieldLink.ID))
-        } else {
-          super.log_info(
-            'processContentTypeFieldRefs',
-            `Adding field ref ${fieldReference.Name} to content type [${contentType.Name}] (${contentType.ID})`
-          )
-          const siteField = this.jsomContext.web
-            .get_fields()
-            .getByInternalNameOrTitle(fieldReference.Name)
-          const fieldLinkCreationInformation = new SP.FieldLinkCreationInformation()
-          fieldLinkCreationInformation.set_field(siteField)
-          fieldLink = spContentType
-            .get_fieldLinks()
-            .add(fieldLinkCreationInformation)
-        }
-        if (contentType.FieldRefs[index].hasOwnProperty('Required')) {
-          fieldLink.set_required(contentType.FieldRefs[index].Required)
-        }
-        if (contentType.FieldRefs[index].hasOwnProperty('Hidden')) {
-          fieldLink.set_hidden(contentType.FieldRefs[index].Hidden)
-        }
-      }
-      spContentType.update(true)
-      await ExecuteJsomQuery(this.jsomContext)
-
-      // Reorder field links to match the order specified in the schema
-      const fieldRefNames = fieldRefs
-        .map((fr) => fr.Name)
-        .filter(Boolean) as string[]
-      if (fieldRefNames.length > 1) {
+    const fieldRefs = contentType.FieldRefs
+    const currentFieldLinks = await this.getCurrentFieldLinks(spContentType)
+    for (const [index, fieldReference] of fieldRefs.entries()) {
+      const existingFieldLink = this.getExistingFieldLink(
+        currentFieldLinks,
+        fieldReference
+      )
+      let fieldLink: SP.FieldLink
+      if (existingFieldLink) {
+        fieldLink = spContentType
+          .get_fieldLinks()
+          .getById(new SP.Guid(existingFieldLink.ID))
+      } else {
         super.log_info(
           'processContentTypeFieldRefs',
-          `Reordering field refs for content type [${contentType.Name}] (${contentType.ID})`
+          `Adding field ref ${fieldReference.Name} to content type [${contentType.Name}] (${contentType.ID})`
         )
-        spContentType.get_fieldLinks().reorder(fieldRefNames)
-        spContentType.update(true)
-        await ExecuteJsomQuery(this.jsomContext)
+        const siteField = this.jsomContext.web
+          .get_fields()
+          .getByInternalNameOrTitle(fieldReference.Name)
+        const fieldLinkCreationInformation = new SP.FieldLinkCreationInformation()
+        fieldLinkCreationInformation.set_field(siteField)
+        fieldLink = spContentType
+          .get_fieldLinks()
+          .add(fieldLinkCreationInformation)
       }
-
-      super.log_info(
-        'processContentTypeFieldRefs',
-        `Successfully processed field refs for content type [${contentType.Name}] (${contentType.ID})`
-      )
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log(error)
-      super.log_info(
-        'processContentTypeFieldRefs',
-        `Failed to process field refs for content type [${contentType.Name}] (${contentType.ID})`,
-        { error: error.args && error.args.get_message() }
-      )
+      if (contentType.FieldRefs[index].hasOwnProperty('Required')) {
+        fieldLink.set_required(contentType.FieldRefs[index].Required)
+      }
+      if (contentType.FieldRefs[index].hasOwnProperty('Hidden')) {
+        fieldLink.set_hidden(contentType.FieldRefs[index].Hidden)
+      }
     }
+    spContentType.update(true)
+    await ExecuteJsomQuery(this.jsomContext)
+
+    // Reorder field links to match the order specified in the schema
+    const fieldRefNames = fieldRefs
+      .map((fr) => fr.Name)
+      .filter(Boolean) as string[]
+    if (fieldRefNames.length > 1) {
+      super.log_info(
+        'processContentTypeFieldRefs',
+        `Reordering field refs for content type [${contentType.Name}] (${contentType.ID})`
+      )
+      spContentType.get_fieldLinks().reorder(fieldRefNames)
+      spContentType.update(true)
+      await ExecuteJsomQuery(this.jsomContext)
+    }
+
+    super.log_info(
+      'processContentTypeFieldRefs',
+      `Successfully processed field refs for content type [${contentType.Name}] (${contentType.ID})`
+    )
   }
 
   private async _initContext(web: IWeb): Promise<void> {

--- a/tests/smoke/deterministic-content-type-ids/README.md
+++ b/tests/smoke/deterministic-content-type-ids/README.md
@@ -34,6 +34,8 @@ verifies that existing content types are updated instead of recreated.
   `0x0101008F279D4FF9A5427D8FA8FE8A5F8BD9E0`.
 - Site content type `SPJS Smoke Child Document` exists with ID
   `0x0101008F279D4FF9A5427D8FA8FE8A5F8BD9E000BDA84E8A7A5F41EFB78D473EC5AF1B86`.
+- Both smoke content types keep the inherited `Title` field link and add the
+  custom smoke field links from the template.
 - List `SPJS Smoke Documents` exists and has content type management enabled.
 - The list content type IDs for both smoke content types start with the
   configured site content type IDs, proving SharePoint created inherited list

--- a/tests/smoke/deterministic-content-type-ids/template.json
+++ b/tests/smoke/deterministic-content-type-ids/template.json
@@ -11,6 +11,12 @@
       "Group": "SPJS Provisioning Smoke",
       "FieldRefs": [
         {
+          "ID": "fa564e0f-0c70-4ab9-b863-0177e6ddd247",
+          "Name": "Title",
+          "Required": false,
+          "Hidden": false
+        },
+        {
           "ID": "D0574E37-5E54-4C42-94B0-29D730235C08",
           "Name": "SPJSSmokeText",
           "Required": false,
@@ -24,6 +30,12 @@
       "Description": "Smoke test child document content type with a deterministic ID.",
       "Group": "SPJS Provisioning Smoke",
       "FieldRefs": [
+        {
+          "ID": "fa564e0f-0c70-4ab9-b863-0177e6ddd247",
+          "Name": "Title",
+          "Required": false,
+          "Hidden": false
+        },
         {
           "ID": "D0574E37-5E54-4C42-94B0-29D730235C08",
           "Name": "SPJSSmokeText",


### PR DESCRIPTION
## Oppsummering

- leser faktiske field links fra SharePoint før handleren legger til refs
- hopper over arvede/eksisterende refs som `Title`, slik at nye content types med fast ID kan få resten av feltene
- lar field ref-feil stoppe provisioning i stedet for å fortsette med halvferdige content types
- utvider smoke-fixturen med `Title` for å dekke denne migreringsstien

## Verifisering

- npm run build
- npm pack --dry-run

