### PR TITLE
fix(lists): make view formatter re-apply resilient and surface errors

### DIFF
--- a/src/handlers/lists.ts
+++ b/src/handlers/lists.ts
@@ -489,23 +489,36 @@ export class Lists extends HandlerBase {
           'processView',
           `View ${lvc.Title} for list ${lc.Title} doesn't exists, creating.`
         )
-        const result = await web.lists
+        await web.lists
           .getByTitle(lc.Title)
           .views.add(lvc.Title, lvc.PersonalView, lvc.AdditionalSettings)
         // SP REST's view-create endpoint silently ignores properties such as
         // CustomFormatter, ViewType2 and Scope. Re-apply AdditionalSettings
-        // via update so newly created views match updated views.
-        await result.view.update(lvc.AdditionalSettings)
+        // via update so newly created views match updated views. Re-resolve
+        // the view by title rather than reusing the IViewAddResult, since the
+        // returned reference is bound to the parent views collection and the
+        // update can silently no-op on some PnPjs/SharePoint combinations.
+        const newView = web.lists
+          .getByTitle(lc.Title)
+          .views.getByTitle(lvc.Title)
+        try {
+          await newView.update(lvc.AdditionalSettings)
+        } catch (err) {
+          super.log_warn(
+            'processView',
+            `Failed to re-apply AdditionalSettings on newly created view ${lvc.Title}: ${err}`
+          )
+        }
         super.log_info(
           'processView',
           `View ${lvc.Title} added successfully to list ${lc.Title}.`
         )
-        await this.processViewFields(result.view, lvc)
+        await this.processViewFields(newView, lvc)
       }
-    } catch {
-      super.log_info(
-        'processViewFields',
-        `Failed to process view for view ${lvc.Title}.`
+    } catch (err) {
+      super.log_error(
+        'processView',
+        `Failed to process view ${lvc.Title}: ${err}`
       )
     }
   }


### PR DESCRIPTION
## Summary

Commit [`2af8d2a`](https://github.com/Puzzlepart/sp-js-provisioning/commit/2af8d2a) (v1.3.7/v1.3.8) added a follow-up `update` after `views.add` to re-apply properties that SP REST's view-create endpoint silently drops (`CustomFormatter`, `ViewType2`, `Scope`). In the field we are still seeing newly created views without their CustomFormatter applied, while the same view definitions apply correctly on subsequent provisioning runs (when the view already exists and the `viewExists` path is hit).

Two issues that can cause this:

1. **Brittle view reference.** `IViewAddResult.view` is bound to the parent `views` collection rather than the new view's ID. On some PnPjs / SharePoint combinations the follow-up `.update(...)` against this reference no-ops or 404s. The `viewExists` path uses `views.getByTitle(...)` and works reliably — using the same pattern here makes the create path symmetric.
2. **Silent failures.** The outer `try { ... } catch { ... }` swallowed every error with a generic `log_info("Failed to process view for view X.")` — no error object, info level. If the post-create `update` throws (which is what we suspect is happening), there is no diagnostic in the log. Changed to `log_error` with the error appended.

## Changes

- Re-resolve the new view via `web.lists.getByTitle(lc.Title).views.getByTitle(lvc.Title)` for the post-create `update`, instead of `IViewAddResult.view`.
- Wrap the post-create `update` in its own `try/catch` with `log_warn`, so a formatter failure does not abort `processViewFields` for that view.
- Replace the outer `catch {}` with `catch (err)` and `log_error` so failures are visible in the provisioning log.
- No behaviour change for the `viewExists` path.

## Test plan

- [ ] Provision a fresh site using a template containing a view with `CustomFormatter` + `ViewType2: "TILES"` (e.g. the Hurtiglenker / Knappevisning view in the Prosjektportalen ROS-Arbeid template) and confirm the tile formatter is applied on the first run.
- [ ] Re-provision the same site (existing view path) and confirm no regression on the update branch.
- [ ] Force the post-create `update` to fail (e.g. invalid JSON in `CustomFormatter`) and confirm the warning is logged and `processViewFields` still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)